### PR TITLE
ES5 Typescript types

### DIFF
--- a/.neutrinorc.js
+++ b/.neutrinorc.js
@@ -43,6 +43,7 @@ module.exports = {
 
       neutrino.on('build', () => {
         fs.copyFileSync(`${neutrino.options.source}/index.d.ts`, join(__dirname, 'build/index.d.ts'));
+        fs.copyFileSync(`${neutrino.options.source}/index.d.ts`, join(__dirname, 'es5/MuiTreeView.d.ts'));
       });
     },
     '@neutrinojs/jest',


### PR DESCRIPTION
Fix to copy types for the es5 build directory too

Relates to #5