### PR TITLE
Material ui icons v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "verdaccio": "^3.2.0"
   },
   "dependencies": {
-    "@material-ui/icons": "^1.1.0",
+    "@material-ui/icons": "^2.0.0",
     "classnames": "^2.2.6",
     "ramda": "^0.25.0"
   },

--- a/test/__snapshots__/MuiTreeView_test.js.snap
+++ b/test/__snapshots__/MuiTreeView_test.js.snap
@@ -99,11 +99,13 @@ Array [
             focusable="false"
             viewBox="0 0 24 24"
           >
-            <g>
-              <path
-                d="M7.41 7.84L12 12.42l4.59-4.58L18 9.25l-6 6-6-6z"
-              />
-            </g>
+            <path
+              d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z"
+            />
+            <path
+              d="M0 0h24v24H0V0z"
+              fill="none"
+            />
           </svg>
         </span>
         <span
@@ -295,11 +297,13 @@ Array [
             focusable="false"
             viewBox="0 0 24 24"
           >
-            <g>
-              <path
-                d="M7.41 7.84L12 12.42l4.59-4.58L18 9.25l-6 6-6-6z"
-              />
-            </g>
+            <path
+              d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z"
+            />
+            <path
+              d="M0 0h24v24H0V0z"
+              fill="none"
+            />
           </svg>
         </span>
         <span
@@ -454,11 +458,13 @@ Array [
                       focusable="false"
                       viewBox="0 0 24 24"
                     >
-                      <g>
-                        <path
-                          d="M7.41 7.84L12 12.42l4.59-4.58L18 9.25l-6 6-6-6z"
-                        />
-                      </g>
+                      <path
+                        d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z"
+                      />
+                      <path
+                        d="M0 0h24v24H0V0z"
+                        fill="none"
+                      />
                     </svg>
                   </span>
                   <span

--- a/yarn.lock
+++ b/yarn.lock
@@ -60,6 +60,18 @@
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
+"@babel/runtime@7.0.0-beta.56":
+  version "7.0.0-beta.56"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.0.0-beta.56.tgz#cda612dffd5b1719a7b8e91e3040bd6ae64de8b0"
+  dependencies:
+    regenerator-runtime "^0.12.0"
+
+"@babel/runtime@7.0.0-rc.1":
+  version "7.0.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.0.0-rc.1.tgz#42f36fc5817911c89ea75da2b874054922967616"
+  dependencies:
+    regenerator-runtime "^0.12.0"
+
 "@babel/runtime@^7.0.0-beta.42":
   version "7.0.0-beta.49"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.0.0-beta.49.tgz#03b3bf07eb982072c8e851dd2ddd5110282e61bf"
@@ -130,11 +142,12 @@
     scroll "^2.0.3"
     warning "^3.0.0"
 
-"@material-ui/icons@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@material-ui/icons/-/icons-1.1.0.tgz#4d025df7b0ba6ace8d6710079ed76013a4d26595"
+"@material-ui/icons@^2.0.0":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@material-ui/icons/-/icons-2.0.3.tgz#d3da9d6e31b1adfbc48efe33c7cb75b32b784096"
   dependencies:
-    recompose "^0.26.0 || ^0.27.0"
+    "@babel/runtime" "7.0.0-rc.1"
+    recompose "^0.28.0"
 
 "@neutrinojs/airbnb-base@^8.1.2":
   version "8.2.3"
@@ -9006,6 +9019,17 @@ recast@~0.11.12:
     react-lifecycles-compat "^3.0.2"
     symbol-observable "^1.0.4"
 
+recompose@^0.28.0:
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/recompose/-/recompose-0.28.2.tgz#19e679227bdf979e0d31b73ffe7ae38c9194f4a7"
+  dependencies:
+    "@babel/runtime" "7.0.0-beta.56"
+    change-emitter "^0.1.2"
+    fbjs "^0.8.1"
+    hoist-non-react-statics "^2.3.1"
+    react-lifecycles-compat "^3.0.2"
+    symbol-observable "^1.0.4"
+
 recursive-readdir@2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/recursive-readdir/-/recursive-readdir-2.2.1.tgz#90ef231d0778c5ce093c9a48d74e5c5422d13a99"
@@ -9053,6 +9077,10 @@ regenerator-runtime@^0.10.5:
 regenerator-runtime@^0.11.0, regenerator-runtime@^0.11.1:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
+
+regenerator-runtime@^0.12.0:
+  version "0.12.1"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz#fa1a71544764c036f8c49b13a08b2594c9f8a0de"
 
 regenerator-transform@^0.10.0:
   version "0.10.1"


### PR DESCRIPTION
To use `@material-ui/core 1.5.1` you must use `@material-ui/icons >= 2.0.0`

If you try to use `@material-ui/icons v1.x.x` with `1.5.1` you receive the following:

```
./node_modules/material-ui-treeview/node_modules/@material-ui/icons/KeyboardArrowDown.js
Module not found: Can't resolve '@babel/runtime/helpers/builtin/interopRequireDefault' in '/<project_dir>/node_modules/material-ui-treeview/node_modules/@material-ui/icons'
```

The Icon being used is `KeyboardArrowDown` which still exists in v2 so shouldn't be a problem. 

Tested in my own application also and can confirm its fine 👍 