### PR TITLE
Use ID for key

### DIFF
--- a/src/components/MuiTreeView/index.jsx
+++ b/src/components/MuiTreeView/index.jsx
@@ -155,7 +155,7 @@ class MuiTreeView extends Component {
       <ExpansionPanel
         classes={expansionPanelClasses}
         style={{ textIndent }}
-        key={typeof id !== "undefined" ? node.id : node.value}
+        key={typeof node.id !== "undefined" ? node.id : node.value}
         elevation={0}
         {...props}
         className={classNames(classes.panel, pickClassName(props))}>

--- a/src/components/MuiTreeView/index.jsx
+++ b/src/components/MuiTreeView/index.jsx
@@ -135,7 +135,7 @@ class MuiTreeView extends Component {
         <ListItem
           disableGutters
           style={{ textIndent }}
-          key={value}
+          key={typeof id !== "undefined" ? id : value}
           id={value}
           value={value}
           onClick={() => this.handleLeafClick({ value, parent, id })}
@@ -155,7 +155,7 @@ class MuiTreeView extends Component {
       <ExpansionPanel
         classes={expansionPanelClasses}
         style={{ textIndent }}
-        key={node.value}
+        key={typeof id !== "undefined" ? node.id : node.value}
         elevation={0}
         {...props}
         className={classNames(classes.panel, pickClassName(props))}>


### PR DESCRIPTION
Gives a way to fix the following error, if your tree contains duplicate values (to be honest i thought #25 did this)

> Warning: Encountered two children with the same key, `<key here>`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.