### PR TITLE
Add a `softSearch` prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ render((
 | tree | object | yes | The data to render as a tree view |
 | onLeafClick | function | no | Callback function fired when a tree leaf is clicked. |
 | searchTerm | string | no | A search term to refine the tree. |
+| softSearch | boolean | no | * Given a `searchTerm`, a subtree will be shown if any parent node higher up in the tree matches the search term. Defaults to `false`. |
 | expansionPanelSummaryProps | object | no | Properties applied to the [ExpansionPanelSummary](https://material-ui.com/api/expansion-panel-summary) element. | 
 | expansionPanelDetailsProps | object | no | Properties applied to the [ExpansionPanelDetails](https://material-ui.com/api/expansion-panel-details) element. |
 | listItemProps | object | no | Properties applied to the [ListItem](https://material-ui.com/api/list-item) element. |

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -5,7 +5,7 @@ import { ListItemProps } from '@material-ui/core/ListItem';
 
 export interface Tree {
   value: string;
-  href?: string
+  href?: string;
   nodes?: Array<string | Tree>;
   id?: string | number;
 }
@@ -20,13 +20,19 @@ export interface MuiTreeViewProps {
    * Callback function fired when a tree leaf is clicked.
    */
   onLeafClick?: (
-    leaf: { value: string; parent: Tree; id?: string | number, href?: string }
+    leaf: { value: string; parent: Tree; id?: string | number; href?: string }
   ) => void;
 
   /**
    * A search term to refine the tree
    */
   searchTerm?: string;
+
+  /**
+   * Given a `searchTerm`, a subtree will be shown if any parent node
+   * higher up in the tree matches the search term. Defaults to false.
+   */
+  softSearch?: boolean;
 
   /**
    * Properties applied to the ExpansionPanelSummary element.


### PR DESCRIPTION
`softSearch`: Given a `searchTerm`, a subtree will be shown if any parent node
higher up in the tree matches the search term. Defaults to false.