### PR TITLE
Feat: Expose all node props when onLeafClick is triggered

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ render((
 | tree | object | yes | The data to render as a tree view |
 | onLeafClick | function | no | Callback function fired when a tree leaf is clicked. |
 | searchTerm | string | no | A search term to refine the tree. |
-| softSearch | boolean | no | * Given a `searchTerm`, a subtree will be shown if any parent node higher up in the tree matches the search term. Defaults to `false`. |
+| softSearch | boolean | no | Given a `searchTerm`, a subtree will be shown if any parent node higher up in the tree matches the search term. Defaults to `false`. |
 | expansionPanelSummaryProps | object | no | Properties applied to the [ExpansionPanelSummary](https://material-ui.com/api/expansion-panel-summary) element. | 
 | expansionPanelDetailsProps | object | no | Properties applied to the [ExpansionPanelDetails](https://material-ui.com/api/expansion-panel-details) element. |
 | listItemProps | object | no | Properties applied to the [ListItem](https://material-ui.com/api/list-item) element. |

--- a/src/components/MuiTreeView/index.jsx
+++ b/src/components/MuiTreeView/index.jsx
@@ -158,7 +158,7 @@ class MuiTreeView extends Component {
           key={typeof id !== 'undefined' ? id : value}
           id={value}
           value={value}
-          onClick={() => this.handleLeafClick({ value, parent, id })}
+          onClick={() => this.handleLeafClick({ ...node, value, parent, id })}
           button
           {...(href
             ? {


### PR DESCRIPTION
Previously we used to expose only `value`, `parent`, and `id`.

Relates to https://github.com/helfi92/material-ui-treeview/issues/34.