### PR TITLE
Mention the TypeScript support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Material-UI Tree View
 
-A React tree view for material-ui.
+A React tree view for material-ui with TypeScript support.
 
 See the demo at https://hassanali.me/material-ui-treeview.
 


### PR DESCRIPTION
I've added a simple mention saying that this project supports TypeScript. I also think that the project description should also be: 
> A React tree view for material-ui<ins> with TypeScript support</ins>   

so it's easier to see it from the GitHub search page.

resolves #39 